### PR TITLE
Refactor deprecated scipy function to cv2 function

### DIFF
--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -5,7 +5,7 @@ import ntpath
 import time
 from . import util, html
 from subprocess import Popen, PIPE
-from scipy.misc import imresize
+from cv2 import resize
 
 if sys.version_info[0] == 2:
     VisdomExceptionBase = Exception
@@ -41,9 +41,9 @@ def save_images(webpage, visuals, image_path, aspect_ratio=1.0, width=256):
             save_path = os.path.join(image_dir, image_name)
             h, w, _ = im.shape
             if aspect_ratio > 1.0:
-                im = imresize(im, (h, int(w * aspect_ratio)), interp='bicubic')
+                im = resize(im, (h, int(w * aspect_ratio)), interpolation='bicubic')
             if aspect_ratio < 1.0:
-                im = imresize(im, (int(h / aspect_ratio), w), interp='bicubic')
+                im = resize(im, (int(h / aspect_ratio), w), interpolation='bicubic')
             util.save_image(im, save_path)
 
             ims.append(image_name)


### PR DESCRIPTION
The imresize function of scipy was deprecated and threw an error on my scipy==1.8.0. Better alternative is cv2's resize function. Function signature as well as interpolation has been maintained without causing any behavioral changes.